### PR TITLE
  Add opts.mkdirpAsync to recurseDir

### DIFF
--- a/copy.js
+++ b/copy.js
@@ -122,6 +122,7 @@ function copyItem (from, to, opts) {
 
 function recurseDir (from, to, opts) {
   validate('SSO', [from, to, opts])
+  opts.mkdirpAsync = promisify(opts.Promise, mkdirp)
   var recurseWith = opts.recurseWith || copyItem
   var fs = opts.fs || nodeFs
   var chown = opts.chown || promisify(Promise, fs.chown)


### PR DESCRIPTION
This PR adds  opts.mkdirpAsync function declarion to recurseDir where it needs to be defined in order to be used to perform async folder copies.  Addresses https://github.com/npm/copy-concurrently/issues/1