### PR TITLE
fix breaking test "use of const in strict mode" in node 0.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,17 +13,17 @@
   "author": "Rebecca Turner <me@re-becca.org> (http://re-becca.org/)",
   "license": "ISC",
   "dependencies": {
-    "aproba": "^1.1.1",
-    "fs-write-stream-atomic": "^1.0.8",
-    "iferr": "^0.1.5",
-    "mkdirp": "^0.5.1",
-    "rimraf": "^2.5.4",
-    "run-queue": "^1.0.0"
+    "aproba": "~1.1.1",
+    "fs-write-stream-atomic": "~1.0.8",
+    "iferr": "~0.1.5",
+    "mkdirp": "~0.5.1",
+    "rimraf": "~2.5.4",
+    "run-queue": "~1.0.0"
   },
   "devDependencies": {
-    "standard": "^8.6.0",
-    "tacks": "^1.2.6",
-    "tap": "^10.1.1"
+    "standard": "~8.6.0",
+    "tacks": "~1.2.6",
+    "tap": "~10.1.1"
   },
   "files": [
     "copy.js",


### PR DESCRIPTION
There was a minor update to tap that introduces an update to a child dependency
which breaks compatibility with node 0.12.x when running `npm test`. By changing
the `^` to a `~` we lock down the dependency tree to only allow for patch
updates.

This fixes the failing travis build for pr npm/copy-concurrently/pull/2