### PR TITLE
copy.js: Fix #8 copy.item ignores uid and gid parameters when run as root

### DIFF
--- a/copy.js
+++ b/copy.js
@@ -99,7 +99,7 @@ function copyItem (from, to, opts) {
     if (err && err.code !== 'ENOENT') return Promise.reject(err)
     return lstat(from)
   }).then(function (fromStat) {
-    var cmdOpts = extend(extend({}, opts), fromStat)
+    var cmdOpts = extend(extend({}, fromStat), opts)
     if (fromStat.isDirectory()) {
       return recurseDir(from, to, cmdOpts)
     } else if (fromStat.isSymbolicLink()) {


### PR DESCRIPTION
The options 'uid, gid' or 'mode' are overwritten by lstat result,
so let's increase options precedence.